### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ See last step on Dockerfile:
         CMD ["java", "-jar", "-Dspring.profiles.active=test", "/opt/spring-boot-rest/target/telenor-product.jar"]
 
 ```
-This image will run the projet with test profile. 
+This image will run the project with test profile. 
 
 ## How to run this image with Docker
 


### PR DESCRIPTION
## Summary
- correct a typo in documentation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6846a510da708328aa63d0c95d4902b0