### PR TITLE
Fix gb_limit field as integer

### DIFF
--- a/src/main/java/com/telenor/products/api/rest/UploadController.java
+++ b/src/main/java/com/telenor/products/api/rest/UploadController.java
@@ -53,7 +53,8 @@ public class UploadController extends AbstractRestHandler {
                         product.setPropertyColor(productProperties.split(":")[1]);
                     } else if (productProperties.toLowerCase(Locale.ROOT).contains("gb_limit")) {
                         product.setProductProperty("gb_limit");
-                        product.setPropertyGbLimit(productProperties.split(":")[1]);
+                        String value = productProperties.split(":")[1];
+                        product.setPropertyGbLimit(Integer.valueOf(value));
                     }
                 }
                 product.setPrice(record.getDouble("Price").intValue());

--- a/src/main/java/com/telenor/products/dao/jpa/ProductSpecs.java
+++ b/src/main/java/com/telenor/products/dao/jpa/ProductSpecs.java
@@ -69,10 +69,12 @@ public class ProductSpecs {
     }
 
     private static Specification<Product> getProductsByPropertyGbLimitMin(String propertyGbLimitMin) {
-        return (root, criteriaQuery, cb) -> cb.greaterThanOrEqualTo(root.get("propertyGbLimit"), propertyGbLimitMin);
+        Integer min = Integer.valueOf(propertyGbLimitMin);
+        return (root, criteriaQuery, cb) -> cb.greaterThanOrEqualTo(root.get("propertyGbLimit"), min);
     }
 
     private static Specification<Product> getProductsByPropertyGbLimitMax(String propertyGbLimitMax) {
-        return (root, criteriaQuery, cb) -> cb.lessThanOrEqualTo(root.get("propertyGbLimit"), propertyGbLimitMax);
+        Integer max = Integer.valueOf(propertyGbLimitMax);
+        return (root, criteriaQuery, cb) -> cb.lessThanOrEqualTo(root.get("propertyGbLimit"), max);
     }
 }

--- a/src/main/java/com/telenor/products/domain/Product.java
+++ b/src/main/java/com/telenor/products/domain/Product.java
@@ -28,7 +28,7 @@ public class Product {
     private String propertyColor;
 
     @Column()
-    private String propertyGbLimit;
+    private Integer propertyGbLimit;
 
     @Column()
     String storeAddress;
@@ -93,11 +93,11 @@ public class Product {
         this.propertyColor = propertyColor;
     }
 
-    public String getPropertyGbLimit() {
+    public Integer getPropertyGbLimit() {
         return propertyGbLimit;
     }
 
-    public void setPropertyGbLimit(String propertyGbLimit) {
+    public void setPropertyGbLimit(Integer propertyGbLimit) {
         this.propertyGbLimit = propertyGbLimit;
     }
 


### PR DESCRIPTION
## Summary
- store `gb_limit` as an integer in `Product`
- parse csv gb_limit values as integers
- compare gb_limit numerically in specs

## Testing
- `mvn test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6846a3408eac832899f3a4d10cdf1376