### PR TITLE
Fix typo in Spring Boot comment

### DIFF
--- a/src/main/java/com/telenor/products/Application.java
+++ b/src/main/java/com/telenor/products/Application.java
@@ -13,7 +13,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 @Configuration
-@EnableAutoConfiguration  // Sprint Boot Auto Configuration
+@EnableAutoConfiguration  // Spring Boot Auto Configuration
 @ComponentScan(basePackages = "com.telenor.products")
 @EnableJpaRepositories("com.telenor.products.dao.jpa")
 public class Application {


### PR DESCRIPTION
## Summary
- correct a typo in `Application.java` comment

## Testing
- `mvn test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6846a53b19f08328923c12b64828d8c6