### PR TITLE
Extend repository with specification executor

### DIFF
--- a/src/main/java/com/telenor/products/dao/jpa/ProductRepository.java
+++ b/src/main/java/com/telenor/products/dao/jpa/ProductRepository.java
@@ -1,14 +1,11 @@
 package com.telenor.products.dao.jpa;
 
 import com.telenor.products.domain.Product;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 /**
  * Repository for db operations
  */
-public interface ProductRepository extends JpaRepository<Product, Long> {
-    List<Product> findAll(Specification<Product> specification);
+public interface ProductRepository extends JpaRepository<Product, Long>, JpaSpecificationExecutor<Product> {
 }


### PR DESCRIPTION
## Summary
- use `JpaSpecificationExecutor` in `ProductRepository`
- rely on the built-in `findAll(Specification)` instead of custom method

## Testing
- `mvn -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6846a52df92883289b6c8189444831a9